### PR TITLE
Add graphql slog into new group

### DIFF
--- a/slog.go
+++ b/slog.go
@@ -77,15 +77,18 @@ func NewSLogGraphQLResponseMiddleware(l *slog.Logger, s VariablesScrubber) graph
 				slog.LevelInfo,
 				"GraphQL Request Served",
 				slog.Group(
-					"req",
-					slog.String("query", oc.RawQuery),
-					slog.Any("variables", s.Scrub(oc.Variables)),
+					"graphql",
+					slog.Group(
+						"req",
+						slog.String("query", oc.RawQuery),
+						slog.Any("variables", s.Scrub(oc.Variables)),
+					),
+					slog.Group(
+						"res",
+						slog.String("errors", res.Errors.Error()),
+					),
+					slog.Duration("duration", time.Since(start)),
 				),
-				slog.Group(
-					"res",
-					slog.String("errors", res.Errors.Error()),
-				),
-				slog.Duration("duration", time.Since(start)),
 			)
 		}
 

--- a/slog_test.go
+++ b/slog_test.go
@@ -99,15 +99,17 @@ var _ = Describe("Logger", func() {
 			subject(graphql.WithOperationContext(context.Background(), oc), handler)
 
 			type logOutput struct {
-				Msg string `json:"msg"`
-				Req struct {
-					Query     string         `json:"query"`
-					Variables map[string]any `json:"variables"`
-				} `json:"req"`
-				Res struct {
-					Errors string `json:"errors"`
-				} `json:"res"`
-				Duration int `json:"duration"`
+				Msg     string `json:"msg"`
+				Graphql struct {
+					Req struct {
+						Query     string         `json:"query"`
+						Variables map[string]any `json:"variables"`
+					} `json:"req"`
+					Res struct {
+						Errors string `json:"errors"`
+					} `json:"res"`
+					Duration int `json:"duration"`
+				} `json:"graphql"`
 			}
 
 			var lo logOutput
@@ -115,10 +117,10 @@ var _ = Describe("Logger", func() {
 			g.Expect(err).To(g.Succeed())
 
 			g.Expect(lo.Msg).To(g.Equal("GraphQL Request Served"))
-			g.Expect(lo.Req.Query).To(g.Equal(query))
-			g.Expect(lo.Req.Variables).To(g.BeNil())
-			g.Expect(lo.Res.Errors).To(g.Equal(fmt.Sprintf("input: %s\n", errMsg)))
-			g.Expect(lo.Duration).To(g.BeNumerically(">", 0))
+			g.Expect(lo.Graphql.Req.Query).To(g.Equal(query))
+			g.Expect(lo.Graphql.Req.Variables).To(g.BeNil())
+			g.Expect(lo.Graphql.Res.Errors).To(g.Equal(fmt.Sprintf("input: %s\n", errMsg)))
+			g.Expect(lo.Graphql.Duration).To(g.BeNumerically(">", 0))
 		})
 	})
 })


### PR DESCRIPTION
## Description

There is a naming conflict in Elastic Search which is causing the GraphQL logs not to be parsed. This will group the graphql request info into a new key, removing the conflict and hopefully allowing us to view logs.

## How did you test the changes?

- Unit test
- Locally

## Dependencies

N/A
