### PR TITLE
Add slog attribute replacer

### DIFF
--- a/slog.go
+++ b/slog.go
@@ -95,3 +95,15 @@ func NewSLogGraphQLResponseMiddleware(l *slog.Logger, s VariablesScrubber) graph
 		return res
 	}
 }
+
+func SLogReplaceAttr(_ []string, a slog.Attr) slog.Attr {
+	switch a.Value.Kind() {
+	case slog.KindAny:
+		switch v := a.Value.Any().(type) {
+		case error:
+			a.Value = slog.GroupValue(slog.String("message", v.Error()))
+		}
+	}
+
+	return a
+}

--- a/slog.go
+++ b/slog.go
@@ -77,15 +77,18 @@ func NewSLogGraphQLResponseMiddleware(l *slog.Logger, s VariablesScrubber) graph
 				slog.LevelInfo,
 				"GraphQL Request Served",
 				slog.Group(
-					"req",
-					slog.String("query", oc.RawQuery),
-					slog.Any("variables", s.Scrub(oc.Variables)),
+					"graphql",
+					slog.Group(
+						"req",
+						slog.String("query", oc.RawQuery),
+						slog.Any("variables", s.Scrub(oc.Variables)),
+					),
+					slog.Group(
+						"res",
+						slog.String("errors", res.Errors.Error()),
+					),
+					slog.Duration("duration", time.Since(start)),
 				),
-				slog.Group(
-					"res",
-					slog.String("errors", res.Errors.Error()),
-				),
-				slog.Duration("duration", time.Since(start)),
 			)
 		}
 

--- a/slog_test.go
+++ b/slog_test.go
@@ -123,4 +123,35 @@ var _ = Describe("Logger", func() {
 			g.Expect(lo.Graphql.Duration).To(g.BeNumerically(">", 0))
 		})
 	})
+
+	Describe("SLogReplaceAttr", func() {
+		It("should return a new slog.Attr with the error message", func() {
+			var (
+				buf    bytes.Buffer
+				logger = slog.New(
+					slog.NewJSONHandler(&buf, &slog.HandlerOptions{ReplaceAttr: SLogReplaceAttr}),
+				)
+				errMsg = "error"
+			)
+
+			logger.ErrorContext(
+				context.Background(),
+				"An error occurred",
+				slog.Any("error", errors.New(errMsg)),
+			)
+
+			var lo struct {
+				Msg   string `json:"msg"`
+				Error struct {
+					Message string `json:"message"`
+				} `json:"error"`
+			}
+
+			err := json.Unmarshal(buf.Bytes(), &lo)
+			g.Expect(err).To(g.Succeed())
+
+			g.Expect(lo.Msg).To(g.Equal("An error occurred"))
+			g.Expect(lo.Error.Message).To(g.Equal(errMsg))
+		})
+	})
 })

--- a/slog_test.go
+++ b/slog_test.go
@@ -99,15 +99,17 @@ var _ = Describe("Logger", func() {
 			subject(graphql.WithOperationContext(context.Background(), oc), handler)
 
 			type logOutput struct {
-				Msg string `json:"msg"`
-				Req struct {
-					Query     string         `json:"query"`
-					Variables map[string]any `json:"variables"`
-				} `json:"req"`
-				Res struct {
-					Errors string `json:"errors"`
-				} `json:"res"`
-				Duration int `json:"duration"`
+				Msg     string `json:"msg"`
+				Graphql struct {
+					Req struct {
+						Query     string         `json:"query"`
+						Variables map[string]any `json:"variables"`
+					} `json:"req"`
+					Res struct {
+						Errors string `json:"errors"`
+					} `json:"res"`
+					Duration int `json:"duration"`
+				} `json:"graphql"`
 			}
 
 			var lo logOutput
@@ -115,10 +117,10 @@ var _ = Describe("Logger", func() {
 			g.Expect(err).To(g.Succeed())
 
 			g.Expect(lo.Msg).To(g.Equal("GraphQL Request Served"))
-			g.Expect(lo.Req.Query).To(g.Equal(query))
-			g.Expect(lo.Req.Variables).To(g.BeNil())
-			g.Expect(lo.Res.Errors).To(g.Equal(fmt.Sprintf("input: %s\n", errMsg)))
-			g.Expect(lo.Duration).To(g.BeNumerically(">", 0))
+			g.Expect(lo.Graphql.Req.Query).To(g.Equal(query))
+			g.Expect(lo.Graphql.Req.Variables).To(g.BeNil())
+			g.Expect(lo.Graphql.Res.Errors).To(g.Equal(fmt.Sprintf("input: %s\n", errMsg)))
+			g.Expect(lo.Graphql.Duration).To(g.BeNumerically(">", 0))
 		})
 	})
 })


### PR DESCRIPTION
## Description

Currently, if an error is logged without a grouping, there is a conflict in Elastic Search which fails to parse the log, rendering it useless. The `ReplaceAttr` function will force an error in a `slog.Any` attribute to change into a group which follows the Elastic Search convention: `error.message`

## How did you test the changes?

- Unit tests

## Dependencies

https://github.com/nrfta/go-log/pull/12